### PR TITLE
Add maxBuffer option and raise default value to 500KiB

### DIFF
--- a/lib/build/handlebars.js
+++ b/lib/build/handlebars.js
@@ -55,7 +55,7 @@ module.exports = function (options, cb) {
         '-e html',
         '-r ' + root
       ].join(' ')
-      exec(command, next)
+      exec(command, {maxBuffer: 500*1024}, next)
     },
     function (stdout, stderr, next) {
       var lines = stdout.split('\n')

--- a/lib/build/handlebars.js
+++ b/lib/build/handlebars.js
@@ -20,6 +20,7 @@ var findHandlebarsBinPath = function (opts) {
 // opts.main
 // opts.paths
 // opts.dist
+// opts.maxBuffer
 module.exports = function (options, cb) {
   var root = options.root
   var defaults = {
@@ -34,6 +35,8 @@ module.exports = function (options, cb) {
   var opts = merge(defaults, options)
 
   var dist = options.dist || 'public/dist'
+
+  var maxBuffer = options.maxBuffer || 500*1024
 
   // remove non-existent folders to prevent handlebars error
   var paths = ''
@@ -55,7 +58,7 @@ module.exports = function (options, cb) {
         '-e html',
         '-r ' + root
       ].join(' ')
-      exec(command, {maxBuffer: 500*1024}, next)
+      exec(command, { maxBuffer: maxBuffer }, next)
     },
     function (stdout, stderr, next) {
       var lines = stdout.split('\n')


### PR DESCRIPTION
This avoids build errors when Handlebars output exceeds the default 200KiB stdout buffer.