### PR TITLE
added headAttributes to html5 template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 6

--- a/shared/layouts/html5/html5.html
+++ b/shared/layouts/html5/html5.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
-  <head>
+  <head {{headAttributes}}>
     <title>{{title}}</title>
     {{#css}}
     <link href="{{.}}" media="all" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This update provides the ability to add attributes to the <head> tag typically used to specify namespaces 